### PR TITLE
Add support for n>1 repeats

### DIFF
--- a/fastchat/llm_judge/common.py
+++ b/fastchat/llm_judge/common.py
@@ -756,3 +756,22 @@ def get_model_list(answer_dir):
     file_paths = glob.glob(f"{answer_dir}/*.jsonl")
     file_names = [os.path.splitext(os.path.basename(f))[0] for f in file_paths]
     return file_names
+
+def expand_model_list(model_list, answer_dir, pre_tag=True):
+    if pre_tag:
+        model_list = [model + '*' for model in model_list]
+    def glob_files(glob_path):
+        file_paths = glob.glob(f"{answer_dir}/{glob_path}.jsonl")
+        file_names = [os.path.splitext(os.path.basename(f))[0] for f in file_paths]
+        return file_names
+    did_pop = False
+    for idx in range(len(model_list)):
+        if '*' in model_list[idx]:
+            glob_path = model_list.pop(idx)
+            model_list += glob_files(glob_path)
+            did_pop = True
+            break
+    if not did_pop:
+        return model_list
+    else:
+        return expand_model_list(model_list, answer_dir, pre_tag=False)

--- a/fastchat/llm_judge/gen_api_answer.py
+++ b/fastchat/llm_judge/gen_api_answer.py
@@ -150,6 +150,7 @@ if __name__ == "__main__":
         "--parallel", type=int, default=1, help="The number of concurrent API calls."
     )
     parser.add_argument("--openai-api-base", type=str, default=None)
+    parser.add_argument("--repeats", type=int, default=1)
     args = parser.parse_args()
 
     if args.openai_api_base is not None:
@@ -158,31 +159,30 @@ if __name__ == "__main__":
     question_file = f"data/{args.bench_name}/question.jsonl"
     questions = load_questions(question_file, args.question_begin, args.question_end)
 
-    if args.answer_file:
-        answer_file = args.answer_file
-    else:
-        answer_file = f"data/{args.bench_name}/model_answer/{args.model_name}.jsonl"
-    print(f"Output to {answer_file}")
+    for idx in range(args.repeats):
+        if args.answer_file:
+            raise NotImplementedError()
+            # answer_file = args.answer_file
+        else:
+            answer_file = f"data/{args.bench_name}/model_answer/{args.model}-{idx+1}.jsonl"
+        print(f"Output to {answer_file}")
 
-    tokenizer = AutoTokenizer.from_pretrained("rajammanabrolu/gpt-4-chat", trust_remote_code=True)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.parallel) as executor:
+            futures = []
+            for question in questions:
+                future = executor.submit(
+                    get_answer,
+                    question,
+                    args.model,
+                    args.num_choices,
+                    args.max_tokens,
+                    answer_file,
+                )
+                futures.append(future)
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=args.parallel) as executor:
-        futures = []
-        for question in questions:
-            future = executor.submit(
-                get_answer,
-                question,
-                args.model,
-                tokenizer,
-                args.num_choices,
-                args.max_tokens,
-                answer_file,
-            )
-            futures.append(future)
+            for future in tqdm.tqdm(
+                concurrent.futures.as_completed(futures), total=len(futures)
+            ):
+                future.result()
 
-        for future in tqdm.tqdm(
-            concurrent.futures.as_completed(futures), total=len(futures)
-        ):
-            future.result()
-
-    reorg_answer_file(answer_file)
+        reorg_answer_file(answer_file)

--- a/fastchat/llm_judge/gen_judgment.py
+++ b/fastchat/llm_judge/gen_judgment.py
@@ -17,6 +17,7 @@ from fastchat.llm_judge.common import (
     play_a_match_pair,
     play_a_match_single,
     get_model_list,
+    expand_model_list,
     Judge,
     MatchPair,
     MatchSingle,
@@ -229,7 +230,7 @@ if __name__ == "__main__":
     if args.model_list is None:
         models = get_model_list(answer_dir)
     else:
-        models = args.model_list
+        models = expand_model_list(args.model_list, answer_dir)
 
     if args.mode == "single":
         judges = make_judge_single(args.judge_model, judge_prompts)


### PR DESCRIPTION
Adds `--repeats <int>` arg to `gen_api_answer.py` and modifies `gen_judgement.py` to handle the file saving patterns that changed as a result of the `gen_api_answers.py` changes.

If you don't use the `--repeats <int>` argument, things should still work just fine.
